### PR TITLE
Fix IMDaemonCore nil pointer on iOS

### DIFF
--- a/Core/Barcelona/Queries/IMDPersistence.swift
+++ b/Core/Barcelona/Queries/IMDPersistence.swift
@@ -228,7 +228,13 @@ public func BLLoadChatItems(_ items: [(chatID: String, messageID: String)]) -> P
 
 typealias IMFileTransferFromIMDAttachmentRecordRefType = @convention(c) (_ record: Any) -> IMFileTransfer?
 
-private let IMDaemonCore = "/System/Library/PrivateFrameworks/IMDaemonCore.framework/Versions/Current/IMDaemonCore".withCString({
+#if os(iOS)
+let IMDaemonCoreLocation = "/System/Library/PrivateFrameworks/IMDaemonCore.framework/IMDaemonCore"
+#else
+let IMDaemonCoreLocation = "/System/Library/PrivateFrameworks/IMDaemonCore.framework/Versions/Current/IMDaemonCore"
+#endif
+
+private let IMDaemonCore = IMDaemonCoreLocation.withCString({
     dlopen($0, RTLD_LAZY)
 })!
 

--- a/Core/Barcelona/Queries/IMDPersistence.swift
+++ b/Core/Barcelona/Queries/IMDPersistence.swift
@@ -228,13 +228,7 @@ public func BLLoadChatItems(_ items: [(chatID: String, messageID: String)]) -> P
 
 typealias IMFileTransferFromIMDAttachmentRecordRefType = @convention(c) (_ record: Any) -> IMFileTransfer?
 
-#if os(iOS)
-let IMDaemonCoreLocation = "/System/Library/PrivateFrameworks/IMDaemonCore.framework/IMDaemonCore"
-#else
-let IMDaemonCoreLocation = "/System/Library/PrivateFrameworks/IMDaemonCore.framework/Versions/Current/IMDaemonCore"
-#endif
-
-private let IMDaemonCore = IMDaemonCoreLocation.withCString({
+private let IMDaemonCore = "/System/Library/PrivateFrameworks/IMDaemonCore.framework/IMDaemonCore".withCString({
     dlopen($0, RTLD_LAZY)
 })!
 


### PR DESCRIPTION
Fixes the crash from https://github.com/open-imcore/barcelona/issues/35.

This fixes receiving i.e. link attachments, but still fails (but not crashes) for images. Will still look into that, but fixing the crash was most critical for now.