### PR TITLE
Try to also match contacts using SwiftyContacts

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/GetContact+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/GetContact+Handler.swift
@@ -11,6 +11,7 @@ import IMFoundation
 import IMSharedUtilities
 import IMCore
 import Barcelona
+import SwiftyContacts
 
 extension IMBusinessNameManager {
     func addCallback(forURI uri: String, callback: @escaping (NSString) -> ()) {
@@ -36,6 +37,7 @@ extension BLContact {
                 return BLContact(first_name: nil, last_name: nil, nickname: nil, avatar: nil, phones: [], emails: [], user_guid: handleID, serviceHint: "iMessage")
             }
         } else {
+            let contacts = (try? SwiftyContacts.fetchContacts(matching: CNPhoneNumber(stringValue: handleID))) ?? []
             let handles = IMHandleRegistrar.sharedInstance().getIMHandles(forID: handleID) ?? []
             
             var firstName: String?, lastName: String?, nickname: String?, suggestedName: String?, avatar: Data?, phoneNumbers = [String](), emailAddresses = [String](), serviceHint: String = "SMS"
@@ -76,6 +78,28 @@ extension BLContact {
                 }
             }
             
+            for handle in contacts {
+                if firstName == nil {
+                    firstName = handle.givenName
+                }
+
+                if lastName == nil {
+                    lastName = handle.familyName
+                }
+
+                if nickname == nil {
+                    nickname = handle.nickname
+                }
+
+                if suggestedName == nil {
+                    suggestedName = handle.organizationName
+                }
+
+                if avatar == nil {
+                    avatar = handle.imageData
+                }
+            }
+
             if firstName == nil, lastName == nil, nickname == nil {
                 if let suggestedName = suggestedName {
                     firstName = suggestedName

--- a/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/GetContact+Handler.swift
+++ b/Beeper/BarcelonaMautrixIPC/IPCHandlers/CommandHandlers/GetContact+Handler.swift
@@ -42,6 +42,28 @@ extension BLContact {
             
             var firstName: String?, lastName: String?, nickname: String?, suggestedName: String?, avatar: Data?, phoneNumbers = [String](), emailAddresses = [String](), serviceHint: String = "SMS"
             
+            for handle in contacts {
+                if firstName == nil {
+                    firstName = handle.givenName
+                }
+
+                if lastName == nil {
+                    lastName = handle.familyName
+                }
+
+                if nickname == nil {
+                    nickname = handle.nickname
+                }
+
+                if suggestedName == nil {
+                    suggestedName = handle.organizationName
+                }
+
+                if avatar == nil {
+                    avatar = handle.imageData
+                }
+            }
+
             for handle in handles {
                 if firstName == nil {
                     firstName = handle.firstName
@@ -75,28 +97,6 @@ extension BLContact {
                 if let cnContact = handle.cnContact {
                     phoneNumbers.append(contentsOf: cnContact.phoneNumbers.map(\.value.stringValue))
                     emailAddresses.append(contentsOf: cnContact.emailAddresses.map { $0.value as String })
-                }
-            }
-            
-            for handle in contacts {
-                if firstName == nil {
-                    firstName = handle.givenName
-                }
-
-                if lastName == nil {
-                    lastName = handle.familyName
-                }
-
-                if nickname == nil {
-                    nickname = handle.nickname
-                }
-
-                if suggestedName == nil {
-                    suggestedName = handle.organizationName
-                }
-
-                if avatar == nil {
-                    avatar = handle.imageData
                 }
             }
 

--- a/project.yml
+++ b/project.yml
@@ -68,6 +68,9 @@ packages:
   FeatureFlags:
     url: https://github.com/EricRabil/FeatureFlags.swift
     from: 1.0.1
+  SwiftyContacts:
+    url: https://github.com/SwiftyContacts/SwiftyContacts
+    from: "4.0"
 
 settings:
   base:
@@ -216,6 +219,7 @@ targets:
       - target: Barcelona
         embed: true
         link: true
+      - package: SwiftyContacts
   barcelona-mautrix:
     group: Beeper
     type: tool


### PR DESCRIPTION
For me on an iPhone, no contact names where resolved. This PR introduces the functionality to also fetch contacts for the given phone number using the SwiftyContacts library, which worked perfectly for me.

It's preferring results from SwiftyContacts, but keeps falling back to the existing contact fetching if no results are found.