### PR TITLE
Add support for compiling for Ventura

### DIFF
--- a/Beeper/BarcelonaMautrixIPC/Commands/Requests/BridgeStatusCommand.swift
+++ b/Beeper/BarcelonaMautrixIPC/Commands/Requests/BridgeStatusCommand.swift
@@ -133,7 +133,7 @@ private extension IMAccountController {
             return false
         }
         
-        // True if the account failed to register, has a known registraiton failure reason, or most recently failed to register
+        // True if the account failed to register, has a known registration failure reason, or most recently failed to register
         var hasAccountError: Bool {
             account.registrationStatus == .failed || account.registrationFailureReason > .unknownError || registrationFailureDate != nil
         }

--- a/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
+++ b/Core/Barcelona/CoreBarcelona/CBDaemonListener.swift
@@ -513,11 +513,11 @@ public class CBDaemonListener: ERBaseDaemonListener {
         }
     }
     
-    // Invoked for status updates (read/deliver/play/save etc)
+    // Invoked for status updates (read/deliver/play/save/edit etc)
     public override func service(_ serviceID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, messagesUpdated messages: [[AnyHashable: Any]]!) {
         *log.debug("messagesUpdated[service]: \(messages.debugDescription, privacy: .public)")
         
-        for message in FZCreateIMMessageItemsFromSerializedArray(messages) {
+        for message in CBCreateItemsFromSerializedArray(messages) {
             switch message {
             case let message as IMMessageItem:
                 self.process(serviceMessage: message, chatIdentifier: chatIdentifier, chatStyle: chatStyle)
@@ -534,7 +534,7 @@ public class CBDaemonListener: ERBaseDaemonListener {
     public override func account(_ accountUniqueID: String!, chat chatIdentifier: String!, style chatStyle: IMChatStyle, chatProperties properties: [AnyHashable : Any]!, messagesUpdated messages: [NSObject]!) {
         *log.debug("messagesUpdated[account]: \(messages.debugDescription, privacy: .public)")
         
-        for message in messages as? [IMItem] ?? FZCreateIMMessageItemsFromSerializedArray(messages) {
+        for message in messages as? [IMItem] ?? CBCreateItemsFromSerializedArray(messages) {
             switch message {
             case let message as IMMessageItem:
                 // This listener call is only for failed messages that are not otherwise caught.
@@ -723,11 +723,11 @@ private extension CBDaemonListener {
                 }
             }
         }
-        
+
         switch newMessage {
         case let item as IMMessageItem:
             currentlyTyping = item.isIncomingTypingMessage() && !item.isCancelTypingMessage()
-            
+
             // typing messages are not part of the timeline anymore
             if item.isTypingMessage {
                 log.debug("ignoring message \(item.guid): typing doesnt flow through here")

--- a/Core/Barcelona/CoreBarcelona/CBLinking.swift
+++ b/Core/Barcelona/CoreBarcelona/CBLinking.swift
@@ -14,6 +14,10 @@ private let log = Logger(category: "CBLinking")
 
 /// A constraint that will either qualify or disqualify a symbol from being selected during reconciliation
 public enum CBLinkerConstraint: Hashable, Equatable, CustomDebugStringConvertible {
+    /// macOS 13, iOS 16, watchOS 9
+    case ventura
+    /// before macOS 13, iOS 16, watchOS 9
+    case preVentura
     /// before macOS 12, iOS 15, watchOS 8
     case preMonterey
     /// macOS 12, iOS 15, watchOS 8
@@ -26,12 +30,16 @@ public enum CBLinkerConstraint: Hashable, Equatable, CustomDebugStringConvertibl
     /// Whether the current environment satisfies the constraint
     public var applies: Bool {
         switch self {
-        case .preMonterey:
-            if #available(macOS 12, iOS 15, watchOS 8, *) {
-                return false
-            } else {
+        case .preVentura:
+            return !Self.ventura.applies
+        case .ventura:
+            if #available(macOS 13, iOS 16, watchOS 9, *) {
                 return true
+            } else {
+                return false
             }
+        case .preMonterey:
+            return !Self.monterey.applies
         case .monterey:
             if #available(macOS 12, iOS 15, watchOS 8, *) {
                 return true
@@ -39,11 +47,7 @@ public enum CBLinkerConstraint: Hashable, Equatable, CustomDebugStringConvertibl
                 return false
             }
         case .preBigSur:
-            if #available(macOS 11, iOS 14, watchOS 7, *) {
-                return false
-            } else {
-                return true
-            }
+            return !Self.bigSur.applies
         case .bigSur:
             if #available(macOS 11, iOS 14, watchOS 7, *) {
                 return true
@@ -55,6 +59,10 @@ public enum CBLinkerConstraint: Hashable, Equatable, CustomDebugStringConvertibl
     
     public var debugDescription: String {
         switch self {
+        case .preVentura:
+            return "preVentura"
+        case .ventura:
+            return "ventura"
         case .preMonterey:
             return "preMonterey"
         case .monterey:

--- a/Core/Barcelona/Extensions/Glue/IMChat+QuerySpecifiers.swift
+++ b/Core/Barcelona/Extensions/Glue/IMChat+QuerySpecifiers.swift
@@ -12,11 +12,11 @@ import IMSharedUtilities
 
 private extension IMChatRegistry {
     func __cb_allGUIDs(forChat chat: IMChat) -> [String] {
-        if self.responds(to: Selector("allGUIDsForChat:")) {
+        if self.responds(to: #selector(self.allGUIDs(forChat:))) {
             return allGUIDs(forChat: chat)
-        } else if self.responds(to: Selector("_allGUIDsForChat:")) {
+        } else if self.responds(to: #selector(self._allGUIDs(forChat:))) {
             return _allGUIDs(forChat: chat)
-        } else if self.responds(to: Selector("_chatGUIDToChatMap")) {
+        } else if self.responds(to: #selector(self._chatGUIDToChatMap)) {
             return _chatGUIDToChatMap().compactMap { id, chatCompare in
                 guard chat == chatCompare else {
                     return nil
@@ -24,7 +24,7 @@ private extension IMChatRegistry {
                 
                 return id
             }
-        } else if self.responds(to: Selector("chatGUIDToChatMap")) {
+        } else if self.responds(to: #selector(self.chatGUIDToChatMap)) {
             return chatGUIDToChatMap().compactMap { id, chatCompare in
                 guard chat == chatCompare else {
                     return nil

--- a/Core/Barcelona/Extensions/Tapbacks/IMChat+Acknowledgment.swift
+++ b/Core/Barcelona/Extensions/Tapbacks/IMChat+Acknowledgment.swift
@@ -33,7 +33,9 @@ public extension IMChat {
         let rawType = Int64(type)
         
 //        sendMessageAcknowledgment(Int64(type), forChatItem: subpart, withMessageSummaryInfo: )
-        guard let summaryInfo = subpart.summaryInfo(for: message, in: self, itemTypeOverride: overridingItemType), let compatibilityString = IMMessageAcknowledgmentStringHelper.generateBackwardCompatibilityString(forMessageAcknowledgmentType: rawType, messageSummaryInfo: summaryInfo), let superFormat = IMCreateSuperFormatStringFromPlainTextString(compatibilityString) else {
+        guard let summaryInfo = subpart.summaryInfo(for: message, in: self, itemTypeOverride: overridingItemType),
+              let compatibilityString = CBGeneratePreviewStringForAcknowledgmentItem(message),
+              let superFormat = IMCreateSuperFormatStringFromPlainTextString(compatibilityString) else {
             throw BarcelonaError(code: 500, message: "Internal server error")
         }
         

--- a/Core/Barcelona/WeakLinks.swift
+++ b/Core/Barcelona/WeakLinks.swift
@@ -1,0 +1,49 @@
+//
+//  WeakLinks.swift
+//  Barcelona
+//
+//  Created by Ian on 10/21/22.
+//
+
+import Foundation
+import IMSharedUtilities
+
+typealias IMCreateItemsFromSerializedArray_t = @convention(c) ([Any]) -> [IMItem]
+typealias IMCreateSerializedItemsFromArray_t = @convention(c) ([IMItem]) -> [Any]?
+
+let CBCreateItemsFromSerializedArray: IMCreateItemsFromSerializedArray_t = CBWeakLink(
+    against: .privateFramework(name: "IMSharedUtilities"),
+    .init(constraints: [.preVentura], symbol: "FZCreateIMMessageItemsFromSerializedArray"),
+    .init(constraints: [.ventura],    symbol: "IMCreateItemsFromSerializedArray")
+)!
+
+let CBCreateSerializedItemsFromArray: IMCreateSerializedItemsFromArray_t = CBWeakLink(
+    against: .privateFramework(name: "IMSharedUtilities"),
+    .init(constraints: [.preVentura], symbol: "FZCreateSerializedIMMessageItemsFromArray"),
+    .init(constraints: [.ventura],    symbol: "IMCreateSerializedItemsFromArray")
+)!
+
+@objc protocol IMMessageAcknowledgmentStringHelper_t: NSObjectProtocol {
+    @objc(generateBackwardCompatibilityStringForMessageAcknowledgmentType:messageSummaryInfo:)
+    static func generateBackwardCompatibilityString(forMessageAcknowledgmentType: Int64, messageSummaryInfo: [AnyHashable: Any]) -> String!
+}
+
+import IMCore
+
+func CBGeneratePreviewStringForAcknowledgmentItem(_ item: IMMessage) -> String! {
+    // Xcode 14.1 shipped with 5.7.1, while Xcode 14.0.1 contains 5.7.
+    // Xcode 14.1 was the first one to contain the Ventura SDK, which contains symbols to link against to call item.tapback(),
+    // so we conditionally compile against it to only compile this when available.
+#if compiler(>=5.7.1)
+    if #available(macOS 13, iOS 16, watchOS 9, *) {
+        guard let tapback = item.tapback() else {
+            return nil
+        }
+        return tapback.previewString(withMessageSummaryInfo: item.messageSummaryInfo, senderDisplayName: item.sender?._displayNameWithAbbreviation, isFromMe: item.isFromMe)
+    }
+#endif // Compiler check
+
+    return NSClassFromString("IMMessageAcknowledgmentStringHelper").map {
+        unsafeBitCast($0, to: IMMessageAcknowledgmentStringHelper_t.Type.self)
+    }?.generateBackwardCompatibilityString(forMessageAcknowledgmentType: item.associatedMessageType, messageSummaryInfo: item.messageSummaryInfo)
+}

--- a/Core/Barcelona/Wrappers/Core/Chat.swift
+++ b/Core/Barcelona/Wrappers/Core/Chat.swift
@@ -156,7 +156,7 @@ public extension Chat {
 // MARK: - Read Receipts
 internal extension IMChat {
     func markDirectRead(items: [IMMessageItem]) {
-        guard let serialized = FZCreateSerializedIMMessageItemsfromArray(items), serialized.count > 0 else {
+        guard let serialized = CBCreateSerializedItemsFromArray(items), serialized.count > 0 else {
             return
         }
         


### PR DESCRIPTION
This adds support for compiling for Ventura by weak-linking against some methods whose names have been changed, and refactors a function which would always run into swiftc's "Took too long to type-check" error so that it doesn't run into that anymore. As far as I can tell, this still compiles well against a 12.3 and a 13.0 sdk, but I haven't extensively tested execution of the parts that were changed to make sure they still work correctly.